### PR TITLE
partially fix orientation of covariance ellipsoid

### DIFF
--- a/src/covariance_visual.cpp
+++ b/src/covariance_visual.cpp
@@ -85,7 +85,6 @@ namespace rviz_plugin_covariance
      std::pair<Eigen::Matrix3d, Eigen::Vector3d>& pair)
     {
       Ogre::Matrix3 rotation;
-      pair.first.normalize ();
       for (unsigned i = 0; i < 3; ++i)
 	for (unsigned j = 0; j < 3; ++j)
 	  rotation[i][j] = pair.first (i, j);


### PR DESCRIPTION
The covariance ellipsoid orientation seems to be wrong, because when getting the rotation from the matrix with the eigen vectors is normalized (whatever that is supposed to do on a matrix).
But this should not be neccessary as the eigen vectors (columns) are already normalized.
