### PR TITLE
Fix 2D poses

### DIFF
--- a/scripts/send_covariance_msgs.py
+++ b/scripts/send_covariance_msgs.py
@@ -43,8 +43,8 @@ while not rospy.is_shutdown():
     ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(r,p,y, axes)
 
     pose_with_cov.pose.covariance[0] = pos_deviation**2.0
-    pose_with_cov.pose.covariance[6+1] = 0.0001
-    pose_with_cov.pose.covariance[12+2] = 0.0001
+    pose_with_cov.pose.covariance[6+1] = 0.001
+    pose_with_cov.pose.covariance[12+2] = 0.001
     pose_with_cov.pose.covariance[18+3] = ori_deviation2**2.0
     pose_with_cov.pose.covariance[24+4] = ori_deviation2**2.0
     pose_with_cov.pose.covariance[30+5] = ori_deviation**2.0

--- a/scripts/send_covariance_msgs_2D.py
+++ b/scripts/send_covariance_msgs_2D.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+import roslib; roslib.load_manifest( 'rviz_plugin_covariance' )
+from geometry_msgs.msg import PoseWithCovarianceStamped, PoseStamped
+import rospy
+from math import cos, sin, pi
+import tf
+import tf_conversions
+
+publisher_cov = rospy.Publisher( 'pose_with_cov', PoseWithCovarianceStamped, queue_size=5 )
+publisher_dyn_pos = rospy.Publisher( 'dyn_pos_pose', PoseStamped, queue_size=5 )
+publisher_dyn_ori = rospy.Publisher( 'dyn_ori_pose', PoseStamped, queue_size=5 )
+
+
+rospy.init_node( 'test_covariance' )
+
+br = tf.TransformBroadcaster()
+rate = rospy.Rate(100)
+# radius = 1
+angle = 0
+# r = 0
+# p = 0
+# y = 0
+
+pos_deviation = 0.5;
+ori_deviation = pi/6.0;
+
+axes = 'sxyz' # 'sxyz' or 'rxyz'
+
+while not rospy.is_shutdown():
+    stamp = rospy.Time.now()
+
+    # Define static pose with covariance
+    pose_with_cov = PoseWithCovarianceStamped()
+    pose_with_cov.header.frame_id = "/base_link"
+    pose_with_cov.header.stamp = stamp
+
+    pose_with_cov.pose.pose.position.x = 1
+    pose_with_cov.pose.pose.position.y = 1
+    pose_with_cov.pose.pose.position.z = 0
+
+    r = 0
+    p = 0
+    y = pi/4.0
+
+    ori = pose_with_cov.pose.pose.orientation
+    ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(r,p,y,axes)
+
+    pose_with_cov.pose.covariance[0] = pos_deviation**2.0
+    pose_with_cov.pose.covariance[6+1] = 0.001
+    pose_with_cov.pose.covariance[12+2] = 0.0
+    pose_with_cov.pose.covariance[18+3] = 0.0
+    pose_with_cov.pose.covariance[24+4] = 0.0
+    pose_with_cov.pose.covariance[30+5] = ori_deviation**2.0
+
+    # Define a dynamic pose that should change position inside the deviation
+    dyn_pos_pose = PoseStamped()
+    dyn_pos_pose.header.frame_id = "/base_link"
+    dyn_pos_pose.header.stamp = stamp
+
+    dyn_pos_pose.pose.position.x = pose_with_cov.pose.pose.position.x + pos_deviation*cos( 10 * angle )
+    dyn_pos_pose.pose.position.y = pose_with_cov.pose.pose.position.y
+    dyn_pos_pose.pose.position.z = pose_with_cov.pose.pose.position.z
+
+    ori = dyn_pos_pose.pose.orientation
+    ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(r,p,y,axes)
+
+    # Define a dynamic pose that should change orientation inside the deviation
+    dyn_ori_pose = PoseStamped()
+    dyn_ori_pose.header.frame_id = "/base_link"
+    dyn_ori_pose.header.stamp = stamp
+
+    dyn_ori_pose.pose.position.x = pose_with_cov.pose.pose.position.x
+    dyn_ori_pose.pose.position.y = pose_with_cov.pose.pose.position.y
+    dyn_ori_pose.pose.position.z = pose_with_cov.pose.pose.position.z
+
+    ori = dyn_ori_pose.pose.orientation
+    ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(r,p,y + ori_deviation*cos( 10 * angle ),axes)
+
+
+    publisher_cov.publish( pose_with_cov )
+    publisher_dyn_pos.publish( dyn_pos_pose )
+    publisher_dyn_ori.publish( dyn_ori_pose )
+
+
+    # br.sendTransform((radius * cos(angle), radius * sin(angle), 0),
+    #                  tf.transformations.quaternion_from_euler(r, p, y),
+    #                  rospy.Time.now(),
+    #                  "base_link",
+    #                  "map")
+    pos, ori = pose_with_cov.pose.pose.position, pose_with_cov.pose.pose.orientation
+    br.sendTransform((pos.x, pos.y, pos.z),
+                     (ori.x, ori.y, ori.z, ori.w),
+                     stamp,
+                     "pose",
+                     "base_link")
+
+    angle += .0005
+    # r = angle
+    # p = angle
+    # y = angle
+    rate.sleep()
+

--- a/scripts/send_odometry.py
+++ b/scripts/send_odometry.py
@@ -8,8 +8,8 @@ from numpy import pi, cos, sin
 
 br = tf.TransformBroadcaster()
 
-topic = 'test_odometry'
-publisher = rospy.Publisher(topic, Odometry, queue_size=5)
+publisher = rospy.Publisher('test_odometry', Odometry, queue_size=5)
+publisher_2D = rospy.Publisher('test_odometry_2D', Odometry, queue_size=5)
 
 rospy.init_node('send_odometry')
 
@@ -17,8 +17,8 @@ y = 0
 angle = 0
 
 roll = 0
-pitch = pi/2
-yaw = 0
+pitch = 0
+yaw = pi/2
 axes = 'sxyz' # 'sxyz' or 'rxyz'
 
 ori_deviation = pi/6.0;
@@ -36,7 +36,7 @@ while not rospy.is_shutdown():
    odo.pose.pose.position.z = 0
 
    ori = odo.pose.pose.orientation
-   ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(roll, pitch + angle, yaw, axes)
+   ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(roll, pitch, yaw + angle, axes)
 
    odo.pose.covariance[0+0*6] = 0.2+(abs(y)/2.5);
    odo.pose.covariance[1+1*6] = 0.2;
@@ -52,6 +52,13 @@ while not rospy.is_shutdown():
       "base_link")
 
    publisher.publish( odo )
+
+   odo.pose.covariance[2+2*6] = 0.0;
+   odo.pose.covariance[3+3*6] = 0.0;
+   odo.pose.covariance[4+4*6] = 0.0;
+
+   publisher_2D.publish( odo )
+
 
    y = y + .02
    if y > 5:

--- a/src/covariance_property.cpp
+++ b/src/covariance_property.cpp
@@ -86,7 +86,7 @@ CovarianceProperty::CovarianceProperty( const QString& name,
   orientation_frame_property_->addOption( "Local", Local );
   orientation_frame_property_->addOption( "Fixed", Fixed );
 
-  orientation_colorstyle_property_ = new EnumProperty( "Color Style", "Unique", "Style to color the orientation covariance",
+  orientation_colorstyle_property_ = new EnumProperty( "Color Style", "Unique", "Style to color the orientation covariance: XYZ with same unique color or following RGB order",
                                       orientation_property_, SLOT( updateColorStyleChoice() ), this );
   orientation_colorstyle_property_->addOption( "Unique", Unique );
   orientation_colorstyle_property_->addOption( "RGB", RGB );
@@ -101,8 +101,8 @@ CovarianceProperty::CovarianceProperty( const QString& name,
   orientation_alpha_property_->setMin( 0 );
   orientation_alpha_property_->setMax( 1 );
   
-  orientation_scale_property_ = new FloatProperty( "Offset", 1.0f,
-                                             "Distance where to position orientation covariance",
+  orientation_scale_property_ = new FloatProperty( "Scale", 1.0f,
+                                             "For 3D poses is the distance where to position orientation covariance. For 2D poses is the size of the triangle representing covariance on yaw",
                                              orientation_property_, SLOT( updateColorAndAlphaAndScale() ), this );
   orientation_scale_property_->setMin( 0 );
 
@@ -175,7 +175,7 @@ void CovarianceProperty::updateVisibility(const CovarianceVisualPtr& visual)
   bool show_covariance = getBool();
   if( !show_covariance )
   {
-    visual->getSceneNode()->setVisible( false );
+    visual->setVisible( false );
   }
   else
   {

--- a/src/covariance_property.cpp
+++ b/src/covariance_property.cpp
@@ -39,8 +39,6 @@
 #include <OgreSceneManager.h>
 #include <OgreSceneNode.h>
 
-#include <boost/make_shared.hpp>
-
 using namespace rviz;
 
 namespace rviz_plugin_covariance

--- a/src/covariance_visual.cpp
+++ b/src/covariance_visual.cpp
@@ -21,7 +21,7 @@ double deg2rad (double degrees) {
 }
 
 CovarianceVisual::CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, bool is_local_rotation, bool is_visible, float pos_scale, float ori_scale)
-: Object( scene_manager ), local_rotation_(is_local_rotation)
+: Object( scene_manager ), local_rotation_(is_local_rotation), pose_2d_(false), orientation_visible_(is_visible)
 {
   // Main node of the visual
   root_node_ = parent_node->createChildSceneNode();
@@ -40,7 +40,7 @@ CovarianceVisual::CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::Sce
   else
     orientation_scale_node_ = fixed_orientation_node_->createChildSceneNode();
 
-  for(int i = 0; i < 3; i++)
+  for(int i = 0; i < kNumOriShapes; i++)
   {
     // Node to position and orient the shape along the axis. One for each axis.
     orientation_offset_node_[i] = orientation_scale_node_->createChildSceneNode();
@@ -48,7 +48,10 @@ CovarianceVisual::CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::Sce
     orientation_offset_node_[i]->setInheritScale( false );
     // Node to be oriented and scaled by the message's covariance. One for each axis.
     orientation_node_[i] = orientation_offset_node_[i]->createChildSceneNode();
-    orientation_shape_[i] = new rviz::Shape(rviz::Shape::Cylinder, scene_manager_, orientation_node_[i]);
+    if(i < kYaw2D)
+      orientation_shape_[i] = new rviz::Shape(rviz::Shape::Cylinder, scene_manager_, orientation_node_[i]);
+    else
+      orientation_shape_[i] = new rviz::Shape(rviz::Shape::Cone, scene_manager_, orientation_node_[i]);
   }
 
   // Position the cylindes at position 1.0 in the respective axis, and perpendicular to the axis.
@@ -61,9 +64,23 @@ CovarianceVisual::CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::Sce
   // z-axis (yaw)
   orientation_offset_node_[kYaw]->setPosition( Ogre::Vector3( Ogre::Vector3::UNIT_Z ) );
   orientation_offset_node_[kYaw]->setOrientation( Ogre::Quaternion( Ogre::Degree( 90 ), Ogre::Vector3::UNIT_X ) );
+  // z-axis (yaw 2D)
+  // NOTE: rviz use a cone defined by the file rviz/ogre_media/models/rviz_cone.mesh, and it's 
+  //       origin is not at the top of the cone. Since we want the top to be at the origin of 
+  //       the pose we need to use an offset here.
+  // WARNING: This number was found by trial-and-error on rviz and it's not the correct 
+  //          one, so changes on scale are expected to cause the top of the cone to move
+  //          from the pose origin, although it's only noticeable with big scales.
+  // FIXME: Find the right value from the cone.mesh file, or implement a class that draws
+  //        something like a 2D "pie slice" and use it instead of the cone.
+  static const double cone_origin_to_top = 0.49115;
+  orientation_offset_node_[kYaw2D]->setPosition(cone_origin_to_top * Ogre::Vector3::UNIT_X);
+  orientation_offset_node_[kYaw2D]->setOrientation(Ogre::Quaternion( Ogre::Degree( 90 ), Ogre::Vector3::UNIT_Z ));
 
   // set initial visibility and scale
-  root_node_->setVisible( is_visible );
+  // root node is always visible. The visibility will be updated on its childs.
+  root_node_->setVisible( true );
+  setVisible( is_visible );
   setScales( pos_scale, ori_scale );
 }
 
@@ -218,7 +235,7 @@ void computeShapeScaleAndOrientation2D(const Eigen::Matrix2d& covariance, Ogre::
   }
 }
 
-void radianScaleToMetricScale(Ogre::Real & radian_scale)
+void radianScaleToMetricScaleBounded(Ogre::Real & radian_scale)
 {
   radian_scale /= 2.0;
   if(radian_scale > deg2rad(85.0)) radian_scale = deg2rad(85.0);
@@ -237,17 +254,32 @@ void CovarianceVisual::setCovariance( const geometry_msgs::PoseWithCovariance& p
       }
   }
 
-  // store position in Ogre structures
+  if(pose.covariance[14] <= 0 && pose.covariance[21] <= 0 && pose.covariance[28] <= 0 )
+    pose_2d_ = true;
+  else
+    pose_2d_ = false;
+
+  updateOrientationVisibility();
+
+  // store orientation in Ogre structure
   Ogre::Quaternion ori(pose.pose.orientation.w, pose.pose.orientation.x, pose.pose.orientation.y, pose.pose.orientation.z);
-  // The position node should follow the orientation of the fixed frame, so we set it here to the inverse of the message's orientation
+  // Set the orientation of the fixed node. Since this node is attached to the root node, it's orientation will be the 
+  // inverse of pose's orientation.
   fixed_orientation_node_->setOrientation(ori.Inverse());
   // Map covariance to a Eigen::Matrix 
   Eigen::Map<const Eigen::Matrix<double,6,6> > covariance(pose.covariance.data());
 
   updatePosition(covariance);
-  updateOrientation(covariance, kRoll);
-  updateOrientation(covariance, kPitch);
-  updateOrientation(covariance, kYaw);
+  if(!pose_2d_)
+  {
+    updateOrientation(covariance, kRoll);
+    updateOrientation(covariance, kPitch);
+    updateOrientation(covariance, kYaw);
+  }
+  else
+  {
+    updateOrientation(covariance, kYaw2D);
+  }
 
 }
 
@@ -256,8 +288,16 @@ void CovarianceVisual::updatePosition( const Eigen::Matrix6d& covariance )
   // Compute shape and orientation for the position part of covariance
   Ogre::Vector3 shape_scale;
   Ogre::Quaternion shape_orientation;
-  // NOTE: we call the 3D version here.
-  computeShapeScaleAndOrientation3D(covariance.topLeftCorner<3,3>(), shape_scale, shape_orientation);
+  if(pose_2d_)
+  {
+    computeShapeScaleAndOrientation2D(covariance.topLeftCorner<2,2>(), shape_scale, shape_orientation, XY_PLANE);
+    // Make the scale in z minimal for better visualization
+    shape_scale.z = 0.001; 
+  }
+  else
+  {
+    computeShapeScaleAndOrientation3D(covariance.topLeftCorner<3,3>(), shape_scale, shape_orientation);
+  }
   // Rotate and scale the position scene node
   position_node_->setOrientation(shape_orientation);
   if(!shape_scale.isNaN())
@@ -266,40 +306,60 @@ void CovarianceVisual::updatePosition( const Eigen::Matrix6d& covariance )
       ROS_WARN_STREAM("position shape_scale contains NaN: " << shape_scale);
 }
 
-void CovarianceVisual::updateOrientation( const Eigen::Matrix6d& covariance, BryanAngle angle )
+void CovarianceVisual::updateOrientation( const Eigen::Matrix6d& covariance, ShapeIndex index )
 {
-  // Get the correct sub-matrix based on the angle
-  Eigen::Matrix2d covarianceAxis;
-  if(angle == kRoll)
-  {
-    covarianceAxis = covariance.bottomRightCorner<2,2>();
-  }
-  else if(angle == kPitch)
-  {
-    covarianceAxis << covariance(3,3), covariance(3,5), covariance(5,3), covariance(5,5);
-  }
-  else // angle == kYaw
-  {
-    covarianceAxis = covariance.block<2,2>(3,3);
-  }
-
   Ogre::Vector3 shape_scale;
   Ogre::Quaternion shape_orientation;
   // Compute shape and orientation for the orientation shape
-  // NOTE: The cylinder mesh is oriented along its y axis, thus we want to flat it out into the XZ plane
-  computeShapeScaleAndOrientation2D(covarianceAxis, shape_scale, shape_orientation, XZ_PLANE);
-  // The computed scale is equivalent to twice the standard deviation _in radians_.
-  // So we need to convert it to the linear scale of the shape using tan().
-  // Also, we bound the maximum std to 85 deg.
-  radianScaleToMetricScale(shape_scale.x);
-  radianScaleToMetricScale(shape_scale.z);
-  // Give a minimal height for the cylinder for better visualization
-  shape_scale.y = 0.001;
+  if(pose_2d_)
+  {
+    // We should only enter on this scope if the index is kYaw2D
+    assert(index == kYaw2D);
+    // 2D poses only depend on yaw.
+    shape_scale.x = 2.0*sqrt(covariance(5,5));
+    // The the covariance is equivalent to twice the standard deviation _in radians_.
+    // So we need to convert it to the linear scale of the shape using tan().
+    // Also, we bound the maximum std to 85 deg.
+    radianScaleToMetricScaleBounded(shape_scale.x);
+    // To display the cone shape properly the scale along y-axis has to be one.
+    shape_scale.y = 1.0;
+    // Give a minimal height for the cone for better visualization
+    shape_scale.z = 0.001;
+  }
+  else
+  {
+    assert(index != kYaw2D);
+
+    // Get the correct sub-matrix based on the index
+    Eigen::Matrix2d covarianceAxis;
+    if(index == kRoll)
+    {
+      covarianceAxis = covariance.bottomRightCorner<2,2>();
+    }
+    else if(index == kPitch)
+    {
+      covarianceAxis << covariance(3,3), covariance(3,5), covariance(5,3), covariance(5,5);
+    }
+    else if(index == kYaw)
+    {
+      covarianceAxis = covariance.block<2,2>(3,3);
+    }
+
+    // NOTE: The cylinder mesh is oriented along its y axis, thus we want to flat it out into the XZ plane
+    computeShapeScaleAndOrientation2D(covarianceAxis, shape_scale, shape_orientation, XZ_PLANE);
+    // The computed scale is equivalent to twice the standard deviation _in radians_.
+    // So we need to convert it to the linear scale of the shape using tan().
+    // Also, we bound the maximum std to 85 deg.
+    radianScaleToMetricScaleBounded(shape_scale.x);
+    radianScaleToMetricScaleBounded(shape_scale.z);
+    // Give a minimal height for the cylinder for better visualization
+    shape_scale.y = 0.001;    
+  }
 
   // Rotate and scale the scene node of the orientation part
-  orientation_node_[angle]->setOrientation(shape_orientation);
+  orientation_node_[index]->setOrientation(shape_orientation);
   if(!shape_scale.isNaN())
-      orientation_node_[angle]->setScale(shape_scale);
+      orientation_node_[index]->setScale(shape_scale);
   else
       ROS_WARN_STREAM("orientation shape_scale contains NaN: " << shape_scale);
 }
@@ -312,17 +372,26 @@ void CovarianceVisual::setScales( float pos_scale, float ori_scale)
 
 void CovarianceVisual::setPositionScale( float pos_scale ) 
 {
-  position_scale_node_->setScale( pos_scale, pos_scale, pos_scale );
+  if(pose_2d_)
+    position_scale_node_->setScale( pos_scale, pos_scale, 1.0 );
+  else
+    position_scale_node_->setScale( pos_scale, pos_scale, pos_scale );
 }
 
 void CovarianceVisual::setOrientationScale( float ori_scale )
 {
+  // Scale the orientation scale node to position the shapes along the axis
   orientation_scale_node_->setScale( ori_scale, ori_scale, ori_scale );
+  // The scale along the flatten out dimension is always 1.0
   for(int i = 0; i < 3; i++)
   {
-    // The scale along the y-axis is always 1.0
-    orientation_offset_node_[i]->setScale( ori_scale, 1.0, ori_scale );    
+    // For the cylinder in 3D case is the y-axis
+    orientation_offset_node_[i]->setScale( ori_scale, 1.0, ori_scale );
   }
+
+  // To proper flat the cone in the 2D case we flat out along z
+  orientation_offset_node_[kYaw2D]->setScale( ori_scale, ori_scale, 1.0 );
+
 }
 
 void CovarianceVisual::setPositionColor(const Ogre::ColourValue& c)
@@ -332,7 +401,7 @@ void CovarianceVisual::setPositionColor(const Ogre::ColourValue& c)
 
 void CovarianceVisual::setOrientationColor(const Ogre::ColourValue& c)
 {
-  for(int i = 0; i < 3; i++)
+  for(int i = 0; i < kNumOriShapes; i++)
   {
     orientation_shape_[i]->setColor(c);
   }
@@ -343,6 +412,7 @@ void CovarianceVisual::setOrientationColorToRGB( float a )
   orientation_shape_[kRoll]->setColor(Ogre::ColourValue(1.0, 0.0, 0.0, a ));
   orientation_shape_[kPitch]->setColor(Ogre::ColourValue(0.0, 1.0, 0.0, a ));
   orientation_shape_[kYaw]->setColor(Ogre::ColourValue(0.0, 0.0, 1.0, a ));
+  orientation_shape_[kYaw2D]->setColor(Ogre::ColourValue(0.0, 0.0, 1.0, a ));
 }
 
 void CovarianceVisual::setPositionColor( float r, float g, float b, float a )
@@ -368,10 +438,16 @@ const Ogre::Quaternion& CovarianceVisual::getPositionCovarianceOrientation()
 void CovarianceVisual::setUserData( const Ogre::Any& data )
 {
   position_shape_->setUserData( data );
-  for(int i = 0; i < 3; i++)
+  for(int i = 0; i < kNumOriShapes; i++)
   {
     orientation_shape_[i]->setUserData( data );
   }
+}
+
+void CovarianceVisual::setVisible( bool visible )
+{
+  setPositionVisible( visible );
+  setOrientationVisible( visible );
 }
 
 void CovarianceVisual::setPositionVisible( bool visible )
@@ -381,8 +457,18 @@ void CovarianceVisual::setPositionVisible( bool visible )
 
 void CovarianceVisual::setOrientationVisible( bool visible )
 {
-  orientation_scale_node_->setVisible( visible );
+  orientation_visible_ = visible;
+  updateOrientationVisibility();
 }
+
+void CovarianceVisual::updateOrientationVisibility()
+{
+  orientation_offset_node_[kRoll]->setVisible( orientation_visible_ && !pose_2d_);
+  orientation_offset_node_[kPitch]->setVisible( orientation_visible_ && !pose_2d_);
+  orientation_offset_node_[kYaw]->setVisible( orientation_visible_ && !pose_2d_);
+  orientation_offset_node_[kYaw2D]->setVisible( orientation_visible_ && pose_2d_);
+}
+
 
 const Ogre::Vector3& CovarianceVisual::getPosition() 
 {
@@ -418,9 +504,9 @@ void CovarianceVisual::setRotatingFrame( bool is_local_rotation )
 
 }
 
-rviz::Shape* CovarianceVisual::getOrientationShape(BryanAngle angle)
+rviz::Shape* CovarianceVisual::getOrientationShape(ShapeIndex index)
 {
-  return orientation_shape_[angle];
+  return orientation_shape_[index];
 }
 
 } // namespace rviz_plugin_covariance

--- a/src/covariance_visual.cpp
+++ b/src/covariance_visual.cpp
@@ -48,7 +48,7 @@ CovarianceVisual::CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::Sce
     orientation_offset_node_[i]->setInheritScale( false );
     // Node to be oriented and scaled by the message's covariance. One for each axis.
     orientation_node_[i] = orientation_offset_node_[i]->createChildSceneNode();
-    if(i < kYaw2D)
+    if(i != kYaw2D)
       orientation_shape_[i] = new rviz::Shape(rviz::Shape::Cylinder, scene_manager_, orientation_node_[i]);
     else
       orientation_shape_[i] = new rviz::Shape(rviz::Shape::Cone, scene_manager_, orientation_node_[i]);
@@ -89,7 +89,7 @@ CovarianceVisual::~CovarianceVisual()
   delete position_shape_;
   scene_manager_->destroySceneNode( position_node_->getName() );
 
-  for(int i = 0; i < 3; i++)
+  for(int i = 0; i < kNumOriShapes; i++)
   {
     delete orientation_shape_[i];
     scene_manager_->destroySceneNode( orientation_node_[i]->getName() );
@@ -383,15 +383,19 @@ void CovarianceVisual::setOrientationScale( float ori_scale )
   // Scale the orientation scale node to position the shapes along the axis
   orientation_scale_node_->setScale( ori_scale, ori_scale, ori_scale );
   // The scale along the flatten out dimension is always 1.0
-  for(int i = 0; i < 3; i++)
+  for(int i = 0; i < kNumOriShapes; i++)
   {
-    // For the cylinder in 3D case is the y-axis
-    orientation_offset_node_[i]->setScale( ori_scale, 1.0, ori_scale );
+    if(i == kYaw2D)
+    {
+      // To proper flat the cone in the 2D case we flat out along z
+      orientation_offset_node_[i]->setScale( ori_scale, ori_scale, 1.0 );
+    }
+    else
+    {
+      // For the cylinder in 3D case is the y-axis
+      orientation_offset_node_[i]->setScale( ori_scale, 1.0, ori_scale );
+    }
   }
-
-  // To proper flat the cone in the 2D case we flat out along z
-  orientation_offset_node_[kYaw2D]->setScale( ori_scale, ori_scale, 1.0 );
-
 }
 
 void CovarianceVisual::setPositionColor(const Ogre::ColourValue& c)

--- a/src/covariance_visual.h
+++ b/src/covariance_visual.h
@@ -9,11 +9,12 @@
 
 #include <Eigen/Dense>
 
+#include <OgreColourValue.h>
+
 namespace Ogre
 {
 class SceneManager;
 class SceneNode;
-class ColourValue;
 class Any;
 }
 
@@ -39,11 +40,13 @@ class CovarianceProperty;
 class CovarianceVisual : public rviz::Object
 {
 public:
-  enum BryanAngle
+  enum ShapeIndex
   {
     kRoll=0,
     kPitch=1,
-    kYaw=2
+    kYaw=2,
+    kYaw2D=3,
+    kNumOriShapes
   };
 
 private:
@@ -105,10 +108,16 @@ public:
   virtual const Ogre::Quaternion& getPositionCovarianceOrientation();
 
   /**
-   * \brief Get the scene node the frame this covariance is defined
-   * @return the scene node associated with frame this covariance is defined
+   * \brief Get the root scene node of the position part of this covariance
+   * @return the root scene node of the position part of this covariance
    */
-  Ogre::SceneNode* getSceneNode() { return root_node_; }
+  Ogre::SceneNode* getPositionSceneNode() { return position_scale_node_; }
+
+  /**
+   * \brief Get the root scene node of the orientation part of this covariance
+   * @return the root scene node of the orientation part of this covariance
+   */
+  Ogre::SceneNode* getOrientationSceneNode() { return orientation_scale_node_; }
 
   /**
    * \brief Get the shape used to display position covariance
@@ -120,12 +129,19 @@ public:
    * \brief Get the shape used to display orientation covariance in an especific axis
    * @return the shape used to display orientation covariance in an especific axis
    */  
-  rviz::Shape* getOrientationShape(BryanAngle angle);
+  rviz::Shape* getOrientationShape(ShapeIndex index);
 
   /**
    * \brief Sets user data on all ogre objects we own
    */
   virtual void setUserData( const Ogre::Any& data );
+
+  /**
+   * \brief Sets visibility of this covariance
+   * 
+   * Convenience method that sets visibility of both position and orientation parts.
+   */
+  virtual void setVisible( bool visible );
 
   /**
    * \brief Sets visibility of the position part of this covariance
@@ -154,7 +170,8 @@ public:
 
 private:
   void updatePosition( const Eigen::Matrix6d& covariance );
-  void updateOrientation( const Eigen::Matrix6d& covariance, BryanAngle angle );
+  void updateOrientation( const Eigen::Matrix6d& covariance, ShapeIndex index );
+  void updateOrientationVisibility();
 
   Ogre::SceneNode* root_node_;
   Ogre::SceneNode* fixed_orientation_node_;
@@ -162,13 +179,17 @@ private:
   Ogre::SceneNode* position_node_;
 
   Ogre::SceneNode* orientation_scale_node_;
-  Ogre::SceneNode* orientation_offset_node_[3];
-  Ogre::SceneNode* orientation_node_[3];
+  Ogre::SceneNode* orientation_offset_node_[4];
+  Ogre::SceneNode* orientation_node_[4];
 
   rviz::Shape* position_shape_;   ///< Ellipse used for the position covariance
-  rviz::Shape* orientation_shape_[3];   ///< Cylinders used for the orientation covariance
+  rviz::Shape* orientation_shape_[4];   ///< Cylinders used for the orientation covariance
 
   bool local_rotation_;
+
+  bool pose_2d_;
+
+  bool orientation_visible_; ///< If the orientation component is visible.
 
 private:
   // Hide Object methods we don't want to expose

--- a/src/covariance_visual.h
+++ b/src/covariance_visual.h
@@ -179,11 +179,11 @@ private:
   Ogre::SceneNode* position_node_;
 
   Ogre::SceneNode* orientation_scale_node_;
-  Ogre::SceneNode* orientation_offset_node_[4];
-  Ogre::SceneNode* orientation_node_[4];
+  Ogre::SceneNode* orientation_offset_node_[kNumOriShapes];
+  Ogre::SceneNode* orientation_node_[kNumOriShapes];
 
   rviz::Shape* position_shape_;   ///< Ellipse used for the position covariance
-  rviz::Shape* orientation_shape_[4];   ///< Cylinders used for the orientation covariance
+  rviz::Shape* orientation_shape_[kNumOriShapes];   ///< Cylinders used for the orientation covariance
 
   bool local_rotation_;
 

--- a/src/odometry_display.cpp
+++ b/src/odometry_display.cpp
@@ -252,7 +252,6 @@ void OdometryDisplay::processMessage( const nav_msgs::Odometry::ConstPtr& messag
     }
   }
 
-
   Ogre::Vector3 position;
   Ogre::Quaternion orientation;
   if( !context_->getFrameManager()->transform( message->header, message->pose.pose, position, orientation ))
@@ -299,7 +298,6 @@ void OdometryDisplay::processMessage( const nav_msgs::Odometry::ConstPtr& messag
   bool use_arrow = (shape_property_->getOptionInt() == ArrowShape);
   arrow->getSceneNode()->setVisible( use_arrow );
   axes->getSceneNode()->setVisible( !use_arrow );
-  // cov->setVisible( covariance_property_->getBool() );
 
   // store everything
   axes_.push_back( axes );

--- a/src/pose_with_covariance_display.cpp
+++ b/src/pose_with_covariance_display.cpp
@@ -218,7 +218,8 @@ void PoseWithCovarianceDisplay::onInitialize()
   coll_handler_.reset( new PoseWithCovarianceDisplaySelectionHandler( this, context_ ));
   coll_handler_->addTrackedObjects( arrow_->getSceneNode() );
   coll_handler_->addTrackedObjects( axes_->getSceneNode() );
-  coll_handler_->addTrackedObjects( covariance_->getSceneNode() );
+  coll_handler_->addTrackedObjects( covariance_->getPositionSceneNode() );
+  coll_handler_->addTrackedObjects( covariance_->getOrientationSceneNode() );
 }
 
 PoseWithCovarianceDisplay::~PoseWithCovarianceDisplay()
@@ -287,7 +288,7 @@ void PoseWithCovarianceDisplay::updateShapeVisibility()
   {
     arrow_->getSceneNode()->setVisible( false );
     axes_->getSceneNode()->setVisible( false );
-    covariance_->getSceneNode()->setVisible( false );
+    covariance_->setVisible( false );
   }
   else
   {


### PR DESCRIPTION
This PR fixes #12 .

Poses 2D are identified as having the elements z, roll and pitch of the covariance matrix's diagonal set to negative. The maximum standard deviation on yaw is set to 85 degrees.

I'll let this PR open for a few days for testing before merging it on indigo branch.