### PR TITLE
Fix 3D orientation

### DIFF
--- a/scripts/send_covariance_msgs.py
+++ b/scripts/send_covariance_msgs.py
@@ -8,7 +8,9 @@ import tf
 import tf_conversions
 
 publisher_cov = rospy.Publisher( 'pose_with_cov', PoseWithCovarianceStamped, queue_size=5 )
-publisher_pose = rospy.Publisher( 'pose', PoseStamped, queue_size=5 )
+publisher_dyn_pos = rospy.Publisher( 'dyn_pos_pose', PoseStamped, queue_size=5 )
+publisher_dyn_ori = rospy.Publisher( 'dyn_ori_pose', PoseStamped, queue_size=5 )
+
 
 rospy.init_node( 'test_covariance' )
 
@@ -20,7 +22,8 @@ angle = 0
 # p = 0
 # y = 0
 
-linear_deviation = 0.5;
+pos_deviation = 0.5;
+ori_deviation = pi/9.0;
 
 
 while not rospy.is_shutdown():
@@ -31,34 +34,53 @@ while not rospy.is_shutdown():
     pose_with_cov.header.frame_id = "/base_link"
     pose_with_cov.header.stamp = stamp
 
-    pose_with_cov.pose.pose.position.x = 3
-    pose_with_cov.pose.pose.position.y = 3
-    pose_with_cov.pose.pose.position.z = 3
+    pose_with_cov.pose.pose.position.x = 1
+    pose_with_cov.pose.pose.position.y = 1
+    pose_with_cov.pose.pose.position.z = 1
+
+    r = pi/2
+    p = pi/3
+    y = 0
 
     ori = pose_with_cov.pose.pose.orientation
-    ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(pi/2,pi/3,0)
+    ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(r,p,y)
 
-    pose_with_cov.pose.covariance[0] = linear_deviation**2.0
+    pose_with_cov.pose.covariance[0] = pos_deviation**2.0
     pose_with_cov.pose.covariance[6+1] = 0.0001
     pose_with_cov.pose.covariance[12+2] = 0.0001
-    pose_with_cov.pose.covariance[18+3] = 0.01
-    pose_with_cov.pose.covariance[24+4] = 0.01
-    pose_with_cov.pose.covariance[30+5] = 0.01
+    pose_with_cov.pose.covariance[18+3] = 0.0001
+    pose_with_cov.pose.covariance[24+4] = 0.0001
+    pose_with_cov.pose.covariance[30+5] = ori_deviation**2.0
 
-    # Define a dynamic pose that should move inside the deviation
-    pose = PoseStamped()
-    pose.header.frame_id = "/base_link"
-    pose.header.stamp = stamp
+    # Define a dynamic pose that should change position inside the deviation
+    dyn_pos_pose = PoseStamped()
+    dyn_pos_pose.header.frame_id = "/base_link"
+    dyn_pos_pose.header.stamp = stamp
 
-    pose.pose.position.x = pose_with_cov.pose.pose.position.x + linear_deviation*cos( 10 * angle )
-    pose.pose.position.y = pose_with_cov.pose.pose.position.y
-    pose.pose.position.z = pose_with_cov.pose.pose.position.z
+    dyn_pos_pose.pose.position.x = pose_with_cov.pose.pose.position.x + pos_deviation*cos( 10 * angle )
+    dyn_pos_pose.pose.position.y = pose_with_cov.pose.pose.position.y
+    dyn_pos_pose.pose.position.z = pose_with_cov.pose.pose.position.z
 
-    ori = pose.pose.orientation
-    ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(pi/2,pi/3,0)
+    ori = dyn_pos_pose.pose.orientation
+    ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(r,p,y)
+
+    # Define a dynamic pose that should change orientation inside the deviation
+    dyn_ori_pose = PoseStamped()
+    dyn_ori_pose.header.frame_id = "/base_link"
+    dyn_ori_pose.header.stamp = stamp
+
+    dyn_ori_pose.pose.position.x = pose_with_cov.pose.pose.position.x
+    dyn_ori_pose.pose.position.y = pose_with_cov.pose.pose.position.y
+    dyn_ori_pose.pose.position.z = pose_with_cov.pose.pose.position.z
+
+    ori = dyn_ori_pose.pose.orientation
+    ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(r,p,y + ori_deviation*cos( 10 * angle ))
+
 
     publisher_cov.publish( pose_with_cov )
-    publisher_pose.publish( pose )
+    publisher_dyn_pos.publish( dyn_pos_pose )
+    publisher_dyn_ori.publish( dyn_ori_pose )
+
 
     # br.sendTransform((radius * cos(angle), radius * sin(angle), 0),
     #                  tf.transformations.quaternion_from_euler(r, p, y),

--- a/scripts/send_odometry.py
+++ b/scripts/send_odometry.py
@@ -4,16 +4,26 @@ import roslib; roslib.load_manifest('rviz')
 from nav_msgs.msg import Odometry
 import rospy
 import tf
-from numpy import pi
+from numpy import pi, cos, sin
 
 br = tf.TransformBroadcaster()
 
 topic = 'test_odometry'
-publisher = rospy.Publisher(topic, Odometry)
+publisher = rospy.Publisher(topic, Odometry, queue_size=5)
 
 rospy.init_node('send_odometry')
 
 y = 0
+angle = 0
+
+roll = 0
+pitch = pi/2
+yaw = 0
+axes = 'sxyz' # 'sxyz' or 'rxyz'
+
+ori_deviation = pi/6.0;
+
+
 while not rospy.is_shutdown():
 
    odo = Odometry()
@@ -26,7 +36,7 @@ while not rospy.is_shutdown():
    odo.pose.pose.position.z = 0
 
    ori = odo.pose.pose.orientation
-   ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(0, pi/2, 0)
+   ori.x, ori.y, ori.z, ori.w = tf.transformations.quaternion_from_euler(roll, pitch + angle, yaw, axes)
 
    odo.pose.covariance[0+0*6] = 0.2+(abs(y)/2.5);
    odo.pose.covariance[1+1*6] = 0.2;
@@ -46,5 +56,9 @@ while not rospy.is_shutdown():
    y = y + .02
    if y > 5:
       y = -5
+
+   angle += .005
+   if angle > 2*pi:
+      angle -= 2*pi
 
    rospy.sleep(0.01)

--- a/src/covariance_property.cpp
+++ b/src/covariance_property.cpp
@@ -31,6 +31,7 @@
 
 #include <rviz/properties/color_property.h>
 #include <rviz/properties/float_property.h>
+#include <rviz/properties/enum_property.h>
 
 #include <QColor>
 
@@ -47,33 +48,49 @@ CovarianceProperty::CovarianceProperty( const QString& name,
                             QObject* receiver )
   : BoolProperty( name, default_value, description, parent, changed_slot, receiver )
 {
-  position_color_property_ = new ColorProperty( "Position Color", QColor( 204, 51, 204 ),
+
+  position_property_ = new BoolProperty( "Position", true,
+                                       "Whether or not to show the position part of covariances",
+                                       this, SIGNAL( changed() ));
+  position_property_->setDisableChildrenIfFalse( true );
+
+  position_color_property_ = new ColorProperty( "Color", QColor( 204, 51, 204 ),
                                              "Color to draw the covariance ellipse.",
-                                             this, SIGNAL( childrenChanged() ) );
+                                             position_property_, SIGNAL( childrenChanged() ), this );
   
-  position_alpha_property_ = new FloatProperty( "Position Alpha", 0.3f,
+  position_alpha_property_ = new FloatProperty( "Alpha", 0.3f,
                                              "0 is fully transparent, 1.0 is fully opaque.",
-                                             this, SIGNAL( childrenChanged() ) );
+                                             position_property_, SIGNAL( childrenChanged() ), this );
   position_alpha_property_->setMin( 0 );
   position_alpha_property_->setMax( 1 );
   
-  position_scale_property_ = new FloatProperty( "Position Scale", 1.0f,
+  position_scale_property_ = new FloatProperty( "Scale", 1.0f,
                                              "Scale factor to be applied to covariance ellipse",
-                                             this, SIGNAL( childrenChanged() ) );
+                                             position_property_, SIGNAL( childrenChanged() ), this );
 
-  orientation_color_property_ = new ColorProperty( "Orientation Color", QColor( 255, 255, 127 ),
+  orientation_property_ = new BoolProperty( "Orientation", true,
+                                          "Whether or not to show the orientation part of covariances",
+                                          this, SIGNAL( changed() ));
+  orientation_property_->setDisableChildrenIfFalse( true );
+
+  orientation_frame_property_ = new EnumProperty( "Frame", "Rotating", "The frame used to display the orientation covariance.",
+                                      orientation_property_, SIGNAL( childrenChanged()), this );
+  orientation_frame_property_->addOption( "Rotating", Rotating );
+  orientation_frame_property_->addOption( "Static", Static );
+
+  orientation_color_property_ = new ColorProperty( "Color", QColor( 255, 255, 127 ),
                                              "Color to draw the covariance ellipse.",
-                                             this, SIGNAL( childrenChanged() ) );
+                                             orientation_property_, SIGNAL( childrenChanged() ), this );
   
-  orientation_alpha_property_ = new FloatProperty( "Orientation Alpha", 0.5f,
+  orientation_alpha_property_ = new FloatProperty( "Alpha", 0.5f,
                                              "0 is fully transparent, 1.0 is fully opaque.",
-                                             this, SIGNAL( childrenChanged() ) );
+                                             orientation_property_, SIGNAL( childrenChanged() ), this );
   orientation_alpha_property_->setMin( 0 );
   orientation_alpha_property_->setMax( 1 );
   
-  orientation_scale_property_ = new FloatProperty( "Orientation Scale", 1.0f,
+  orientation_scale_property_ = new FloatProperty( "Scale", 1.0f,
                                              "Scale factor to be applied to covariance ellipse",
-                                             this, SIGNAL( childrenChanged() ) );
+                                             orientation_property_, SIGNAL( childrenChanged() ), this );
 
   setDisableChildrenIfFalse( true );
 }
@@ -121,5 +138,21 @@ float CovarianceProperty::getOrientationScale()
 {
   orientation_scale_property_->getFloat();
 }
+
+bool CovarianceProperty::getPositionBool() const
+{
+  return position_property_->getBool();
+}
+
+bool CovarianceProperty::getOrientationBool() const
+{
+  return orientation_property_->getBool();
+}
+
+int CovarianceProperty::getOrientationFrameOptionInt() const
+{
+  return orientation_frame_property_->getOptionInt();
+}
+
 
 } // end namespace rviz_plugin_covariance

--- a/src/covariance_property.cpp
+++ b/src/covariance_property.cpp
@@ -36,6 +36,11 @@
 
 #include <QColor>
 
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+
+#include <boost/make_shared.hpp>
+
 using namespace rviz;
 
 namespace rviz_plugin_covariance
@@ -150,7 +155,7 @@ void CovarianceProperty::updateVisibility(const CovarianceVisualPtr& visual)
   bool show_covariance = getBool();
   if( !show_covariance )
   {
-    visual->setVisible( false );
+    visual->getSceneNode()->setVisible( false );
   }
   else
   {
@@ -175,14 +180,6 @@ void CovarianceProperty::updateOrientationFrame(const CovarianceVisualPtr& visua
   visual->setRotatingFrame( use_rotating_frame );
 }
 
-void CovarianceProperty::pushBackVisual( const CovarianceVisualPtr& visual )
-{
-  updateVisibility(visual);
-  updateOrientationFrame(visual);
-  updateColorAndAlphaAndScale(visual);
-  covariances_.push_back(visual);
-}
-
 void CovarianceProperty::popFrontVisual()
 {
   covariances_.pop_front();
@@ -197,5 +194,28 @@ size_t CovarianceProperty::sizeVisual()
 {
   return covariances_.size();
 }
+
+CovarianceProperty::CovarianceVisualPtr CovarianceProperty::createAndPushBackVisual(Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node)
+{
+  bool use_rotating_frame = ( orientation_frame_property_->getOptionInt() == Rotating );
+  CovarianceVisualPtr visual(new CovarianceVisual(scene_manager, parent_node, use_rotating_frame) );
+  updateVisibility(visual);
+  updateOrientationFrame(visual);
+  updateColorAndAlphaAndScale(visual);
+  covariances_.push_back(visual);
+  return visual;
+}
+
+bool CovarianceProperty::getPositionBool()
+{
+  return position_property_->getBool();
+}
+
+bool CovarianceProperty::getOrientationBool()
+{
+  return orientation_property_->getBool();
+}
+
+
 
 } // end namespace rviz_plugin_covariance

--- a/src/covariance_property.h
+++ b/src/covariance_property.h
@@ -18,11 +18,15 @@ class EnumProperty;
 namespace rviz_plugin_covariance
 {
 
+class CovarianceVisual;
+
 /** @brief Property specialized to provide getter for booleans. */
 class CovarianceProperty: public rviz::BoolProperty
 {
 Q_OBJECT
 public:
+  typedef boost::shared_ptr<CovarianceVisual> CovarianceVisualPtr;
+
   enum Frame
   {
     Rotating,
@@ -38,24 +42,25 @@ public:
 
   virtual ~CovarianceProperty();
 
-  Ogre::ColourValue getPositionOgreColor();
-  QColor getPositionColor() const;
-  float getPositionAlpha();
-  float getPositionScale();
-  virtual bool getPositionBool() const;
+  // Methods to manage the deque of Covariance Visuals
+  void pushBackVisual( const CovarianceVisualPtr& visual );
+  void popFrontVisual();
+  void clearVisual();
+  size_t sizeVisual();
 
-  Ogre::ColourValue getOrientationOgreColor();
-  QColor getOrientationColor() const;
-  float getOrientationAlpha();
-  float getOrientationScale();
-  virtual bool getOrientationBool() const;
-
-  virtual int getOrientationFrameOptionInt() const;
-
-Q_SIGNALS:
-  bool childrenChanged();
+private Q_SLOTS:
+  void updateColorAndAlphaAndScale();
+  void updateOrientationFrame();
+  void updateVisibility();
 
 private:
+  void updateColorAndAlphaAndScale( const CovarianceVisualPtr& visual );
+  void updateOrientationFrame( const CovarianceVisualPtr& visual );
+  void updateVisibility( const CovarianceVisualPtr& visual );
+
+  typedef std::deque<CovarianceVisualPtr> D_Covariance;
+  D_Covariance covariances_;
+
   rviz::BoolProperty*  position_property_;
   rviz::ColorProperty* position_color_property_;
   rviz::FloatProperty* position_alpha_property_;

--- a/src/covariance_property.h
+++ b/src/covariance_property.h
@@ -12,6 +12,7 @@ namespace rviz
 class Property;
 class ColorProperty;
 class FloatProperty;
+class EnumProperty;
 }
 
 namespace rviz_plugin_covariance
@@ -22,6 +23,12 @@ class CovarianceProperty: public rviz::BoolProperty
 {
 Q_OBJECT
 public:
+  enum Frame
+  {
+    Rotating,
+    Static,
+  };
+
   CovarianceProperty( const QString& name = "Covariance",
                 bool default_value = false,
                 const QString& description = QString(),
@@ -35,19 +42,26 @@ public:
   QColor getPositionColor() const;
   float getPositionAlpha();
   float getPositionScale();
+  virtual bool getPositionBool() const;
 
   Ogre::ColourValue getOrientationOgreColor();
   QColor getOrientationColor() const;
   float getOrientationAlpha();
   float getOrientationScale();
+  virtual bool getOrientationBool() const;
+
+  virtual int getOrientationFrameOptionInt() const;
 
 Q_SIGNALS:
   bool childrenChanged();
 
 private:
+  rviz::BoolProperty*  position_property_;
   rviz::ColorProperty* position_color_property_;
   rviz::FloatProperty* position_alpha_property_;
   rviz::FloatProperty* position_scale_property_;
+  rviz::BoolProperty*  orientation_property_;
+  rviz::EnumProperty*  orientation_frame_property_;
   rviz::ColorProperty* orientation_color_property_;
   rviz::FloatProperty* orientation_alpha_property_;
   rviz::FloatProperty* orientation_scale_property_;

--- a/src/covariance_property.h
+++ b/src/covariance_property.h
@@ -35,8 +35,14 @@ public:
 
   enum Frame
   {
-    Rotating,
-    Static,
+    Local,
+    Fixed,
+  };
+
+  enum ColorStyle
+  {
+    Unique,
+    RGB,
   };
 
   CovarianceProperty( const QString& name = "Covariance",
@@ -63,6 +69,7 @@ public Q_SLOTS:
 private Q_SLOTS:
   void updateColorAndAlphaAndScale();
   void updateOrientationFrame();
+  void updateColorStyleChoice();
 
 private:
   void updateColorAndAlphaAndScale( const CovarianceVisualPtr& visual );
@@ -78,6 +85,7 @@ private:
   rviz::FloatProperty* position_scale_property_;
   rviz::BoolProperty*  orientation_property_;
   rviz::EnumProperty*  orientation_frame_property_;
+  rviz::EnumProperty*  orientation_colorstyle_property_;
   rviz::ColorProperty* orientation_color_property_;
   rviz::FloatProperty* orientation_alpha_property_;
   rviz::FloatProperty* orientation_scale_property_;

--- a/src/covariance_property.h
+++ b/src/covariance_property.h
@@ -15,6 +15,12 @@ class FloatProperty;
 class EnumProperty;
 }
 
+namespace Ogre
+{
+  class SceneManager;
+  class SceneNode;
+}
+
 namespace rviz_plugin_covariance
 {
 
@@ -42,16 +48,21 @@ public:
 
   virtual ~CovarianceProperty();
 
+  bool getPositionBool();
+  bool getOrientationBool();
+
   // Methods to manage the deque of Covariance Visuals
-  void pushBackVisual( const CovarianceVisualPtr& visual );
+  CovarianceVisualPtr createAndPushBackVisual(Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node);
   void popFrontVisual();
   void clearVisual();
   size_t sizeVisual();
 
+public Q_SLOTS:
+  void updateVisibility();
+
 private Q_SLOTS:
   void updateColorAndAlphaAndScale();
   void updateOrientationFrame();
-  void updateVisibility();
 
 private:
   void updateColorAndAlphaAndScale( const CovarianceVisualPtr& visual );

--- a/src/covariance_visual.cpp
+++ b/src/covariance_visual.cpp
@@ -393,6 +393,18 @@ void CovarianceVisual::setVisible( bool visible )
   frame_node_->setVisible( visible );
 }
 
+void CovarianceVisual::setPositionVisible( bool visible )
+{
+  position_node_->setVisible( visible );
+}
+
+void CovarianceVisual::setOrientationVisible( bool visible )
+{
+  orientation_x_node_->setVisible( visible );
+  orientation_y_node_->setVisible( visible );
+  orientation_z_node_->setVisible( visible );
+}
+
 const Ogre::Vector3& CovarianceVisual::getPosition() 
 {
   return position_node_->getPosition();

--- a/src/covariance_visual.cpp
+++ b/src/covariance_visual.cpp
@@ -18,6 +18,10 @@ using namespace rviz;
 namespace rviz_plugin_covariance
 {
 
+double deg2rad (double degrees) {
+    return degrees * 4.0 * atan (1.0) / 180.0;
+}
+
 CovarianceVisual::CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, bool is_visible, float pos_scale, float ori_scale)
 : Object( scene_manager ),
   position_scale_factor_( 1.0f ), orientation_scale_factor_( 1.0f ),
@@ -30,7 +34,7 @@ CovarianceVisual::CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::Sce
   position_shape_ = new rviz::Shape(rviz::Shape::Sphere, scene_manager_, position_node_);
 
   orientation_node_ = frame_node_->createChildSceneNode();
-  orientation_shape_ = new rviz::Shape(rviz::Shape::Cone, scene_manager_, orientation_node_);
+  orientation_shape_ = new rviz::Shape(rviz::Shape::Cylinder, scene_manager_, orientation_node_);
 
   setVisible( is_visible );
 
@@ -47,7 +51,7 @@ CovarianceVisual::~CovarianceVisual()
   scene_manager_->destroySceneNode( frame_node_->getName() );
 }
 
-// Local function to force the axis to be right handed. Taken from ecl_statistics
+// Local function to force the axis to be right handed for 3D. Taken from ecl_statistics
 void makeRightHanded( Eigen::Matrix3d& eigenvectors, Eigen::Vector3d& eigenvalues)
 {
   // Note that sorting of eigenvalues may end up with left-hand coordinate system.
@@ -64,7 +68,23 @@ void makeRightHanded( Eigen::Matrix3d& eigenvectors, Eigen::Vector3d& eigenvalue
   }
 }
 
-void computeShapeScaleAndOrientation(const Eigen::Matrix3d& covariance, Ogre::Vector3& scale, Ogre::Quaternion& orientation)
+// Local function to force the axis to be right handed for 2D. Based on the one from ecl_statistics
+void makeRightHanded( Eigen::Matrix2d& eigenvectors, Eigen::Vector2d& eigenvalues)
+{
+  // Note that sorting of eigenvalues may end up with left-hand coordinate system.
+  // So here we correctly sort it so that it does end up being righ-handed and normalised.
+  Eigen::Vector3d c0;  c0.setZero();  c0.head<2>() = eigenvectors.col(0);  c0.normalize();
+  Eigen::Vector3d c1;  c1.setZero();  c1.head<2>() = eigenvectors.col(1);  c1.normalize();
+  Eigen::Vector3d cc = c0.cross(c1);
+  if (cc[2] < 0) {
+    eigenvectors << c1.head<2>(), c0.head<2>();
+    double e = eigenvalues[0];  eigenvalues[0] = eigenvalues[1];  eigenvalues[1] = e;
+  } else {
+    eigenvectors << c0.head<2>(), c1.head<2>();
+  }
+}
+
+void computeShapeScaleAndOrientation3D(const Eigen::Matrix3d& covariance, Ogre::Vector3& scale, Ogre::Quaternion& orientation)
 {
   Eigen::Vector3d eigenvalues(Eigen::Vector3d::Identity());
   Eigen::Matrix3d eigenvectors(Eigen::Matrix3d::Zero());
@@ -99,6 +119,79 @@ void computeShapeScaleAndOrientation(const Eigen::Matrix3d& covariance, Ogre::Ve
   scale.z = 2*std::sqrt (eigenvalues[2]);
 }
 
+enum Plane {
+  YZ_PLANE, // normal is x-axis
+  XZ_PLANE, // normal is y-axis
+  XY_PLANE  // normal is z-axis
+};
+
+void computeShapeScaleAndOrientation2D(const Eigen::Matrix2d& covariance, Ogre::Vector3& scale, Ogre::Quaternion& orientation, Plane plane = XY_PLANE)
+{
+  Eigen::Vector2d eigenvalues(Eigen::Vector2d::Identity());
+  Eigen::Matrix2d eigenvectors(Eigen::Matrix2d::Zero());
+
+  // NOTE: The SelfAdjointEigenSolver only references the lower triangular part of the covariance matrix
+  // FIXME: Should we use Eigen's pseudoEigenvectors() ?
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix2d> eigensolver(covariance);
+  // Compute eigenvectors and eigenvalues
+  if (eigensolver.info () == Eigen::Success)
+  {
+    eigenvalues = eigensolver.eigenvalues();
+    eigenvectors = eigensolver.eigenvectors();
+  }
+  else
+  {
+    ROS_WARN_THROTTLE(1, "failed to compute eigen vectors/values for position. Is the covariance matrix correct?");
+    eigenvalues = Eigen::Vector2d::Zero();      // Setting the scale to zero will hide it on the screen
+    eigenvectors = Eigen::Matrix2d::Identity();
+  }
+
+  // Be sure we have a right-handed orientation system
+  makeRightHanded(eigenvectors, eigenvalues);
+
+  // Define the rotation and scale of the plane
+  // The Eigenvalues are the variances. The scales are two times the standard
+  // deviation. The scale of the missing dimension is set to zero.
+  if(plane == YZ_PLANE)
+  {
+    orientation.FromRotationMatrix(Ogre::Matrix3(1,        0,                 0,
+                                                 0, eigenvectors(0,0), eigenvectors(0,1),
+                                                 0, eigenvectors(1,0), eigenvectors(1,1)));
+
+    scale.x = 0;
+    scale.y = 2*std::sqrt (eigenvalues[0]);
+    scale.z = 2*std::sqrt (eigenvalues[1]);
+
+  }
+  else if(plane == XZ_PLANE)
+  {
+    orientation.FromRotationMatrix(Ogre::Matrix3(eigenvectors(0,0), 0, eigenvectors(0,1),
+                                                        0,          1,        0,
+                                                 eigenvectors(1,0), 0, eigenvectors(1,1)));
+
+    scale.x = 2*std::sqrt (eigenvalues[0]);
+    scale.y = 0;
+    scale.z = 2*std::sqrt (eigenvalues[1]);
+  }
+  else // plane == XY_PLANE
+  {
+    orientation.FromRotationMatrix(Ogre::Matrix3(eigenvectors(0,0), eigenvectors(0,1), 0,
+                                                 eigenvectors(1,0), eigenvectors(1,1), 0,
+                                                        0,                 0,          1));
+
+    scale.x = 2*std::sqrt (eigenvalues[0]);
+    scale.y = 2*std::sqrt (eigenvalues[1]);
+    scale.z = 0;
+  }
+}
+
+void radianScaleToMetricScale(Ogre::Real & radian_scale)
+{
+  radian_scale /= 2.0;
+  if(radian_scale > deg2rad(85.0)) radian_scale = deg2rad(85.0);
+  radian_scale = 2.0 * tan(radian_scale);
+}
+
 // This method compute the eigenvalues and eigenvectors of the position and orientation part covariance matrix
 // separatelly and use their values to rotate and scale the covarance shapes.
 void CovarianceVisual::setCovariance( const geometry_msgs::PoseWithCovariance& message )
@@ -122,7 +215,8 @@ void CovarianceVisual::setCovariance( const geometry_msgs::PoseWithCovariance& m
   // Compute shape and orientation for the position part of covariance
   Ogre::Vector3 shape_scale;
   Ogre::Quaternion shape_orientation;
-  computeShapeScaleAndOrientation(covariance.topLeftCorner<3,3>(), shape_scale, shape_orientation);
+  // NOTE: we call the 3D version here.
+  computeShapeScaleAndOrientation3D(covariance.topLeftCorner<3,3>(), shape_scale, shape_orientation);
   // store the shape (needed if the scale factor changes later)
   (*position_msg_scale_) = shape_scale;
   // update the shape by the scale factor
@@ -136,15 +230,30 @@ void CovarianceVisual::setCovariance( const geometry_msgs::PoseWithCovariance& m
   else
       ROS_WARN_STREAM("position shape_scale contains NaN: " << shape_scale);
 
-  // Repeat the same for the orientation part of the covariance matrix
-  computeShapeScaleAndOrientation(covariance.bottomRightCorner<3,3>(), shape_scale, shape_orientation);
+  // Compute shape and orientation for the orientation shape on the x-axis (roll)
+  // NOTE: The cylinder mesh is oriented along its y axis, thus we want to flat it out into the XZ plane
+  computeShapeScaleAndOrientation2D(covariance.bottomRightCorner<2,2>(), shape_scale, shape_orientation, XZ_PLANE);
+  // The computed scale is equivalent to twice the standard deviation _in radians_.
+  // So we need to convert it to the linear scale of the shape using tan().
+  // Also, we bound the maximum std to 85 deg.
+  radianScaleToMetricScale(shape_scale.x);
+  radianScaleToMetricScale(shape_scale.z);
+  // Give a minimal height for the cylinder for better visualization
+  shape_scale.y = 0.001;
+  // store the shape (needed if the scale factor changes later)
   (*orientation_msg_scale_) = shape_scale;
+  // update the shape by the scale factor
   shape_scale *= orientation_scale_factor_;
 
   // Position, rotate and scale the scene node of the orientation part
-  // Note the shape_orientation is composed with the msg_orientation
-  orientation_node_->setPosition(msg_position);
-  orientation_node_->setOrientation(msg_orientation * shape_orientation);
+  // Note we position the cylinder along the x-axis
+  orientation_node_->setPosition(msg_position + msg_orientation * (orientation_scale_factor_ * Ogre::Vector3(1.0,0,0)));
+  // Note the shape_orientation is composed with the msg_orientation.
+  // The rotations in the midle make the cylinder perpendicular to pose's x-axis.
+  orientation_node_->setOrientation(msg_orientation *
+    Ogre::Quaternion( Ogre::Degree( 90 ), Ogre::Vector3::UNIT_X ) *
+    Ogre::Quaternion( Ogre::Degree( 90 ), Ogre::Vector3::UNIT_Z ) *
+    shape_orientation);
   if(!shape_scale.isNaN())
       orientation_node_->setScale(shape_scale);
   else

--- a/src/covariance_visual.cpp
+++ b/src/covariance_visual.cpp
@@ -234,6 +234,11 @@ void setOrientationShape(
   // Note the shape_orientation is composed with the orientation.
   // The axis_aligment should make the cylinder perpendicular to the axis
   node->setOrientation(orientation * axis_alignment * shape_orientation);
+
+  // FIXME: The following lines can be used if the message rotation is being represented in the static frame
+  // node->setPosition(position + scale_factor * offset);
+  // node->setOrientation(axis_alignment * shape_orientation);
+
   if(!shape_scale.isNaN())
       node->setScale(shape_scale);
   else

--- a/src/covariance_visual.cpp
+++ b/src/covariance_visual.cpp
@@ -332,11 +332,17 @@ void CovarianceVisual::setPositionColor(const Ogre::ColourValue& c)
 
 void CovarianceVisual::setOrientationColor(const Ogre::ColourValue& c)
 {
-  // FIXME: Is it better fix to rgb color? Or give the option to the user
   for(int i = 0; i < 3; i++)
   {
     orientation_shape_[i]->setColor(c);
   }
+}
+
+void CovarianceVisual::setOrientationColorToRGB( float a )
+{
+  orientation_shape_[kRoll]->setColor(Ogre::ColourValue(1.0, 0.0, 0.0, a ));
+  orientation_shape_[kPitch]->setColor(Ogre::ColourValue(0.0, 1.0, 0.0, a ));
+  orientation_shape_[kYaw]->setColor(Ogre::ColourValue(0.0, 0.0, 1.0, a ));
 }
 
 void CovarianceVisual::setPositionColor( float r, float g, float b, float a )

--- a/src/covariance_visual.h
+++ b/src/covariance_visual.h
@@ -92,6 +92,7 @@ public:
    */
   virtual void setOrientationColor( float r, float g, float b, float a );
   void setOrientationColor(const Ogre::ColourValue& color);
+  void setOrientationColorToRGB(float a);
 
   /** @brief Set the covariance.
    *

--- a/src/covariance_visual.h
+++ b/src/covariance_visual.h
@@ -83,8 +83,6 @@ public:
 
   virtual const Ogre::Vector3& getPositionCovarianceScale();
   virtual const Ogre::Quaternion& getPositionCovarianceOrientation();
-  virtual const Ogre::Vector3& getOrientationCovarianceScale();
-  virtual const Ogre::Quaternion& getOrientationCovarianceOrientation();
 
   /**
    * \brief Get the scene node the frame this covariance is defined
@@ -102,10 +100,12 @@ public:
    * \brief Get the scene node associated with the orientation covariance
    * @return the scene node associated with the orientation covariance
    */
-  Ogre::SceneNode* getOrientationSceneNode() { return orientation_node_; }
+  // TODO: Add methods to get other orientation scene nodes as well
+  Ogre::SceneNode* getOrientationSceneNode() { return orientation_x_node_; }
 
   rviz::Shape* getPositionShape() { return position_shape_; }
-  rviz::Shape* getOrientationShape() { return orientation_shape_; }
+  // TODO: Add methods to get other orientation shapes as well
+  rviz::Shape* getOrientationShape() { return orientation_x_shape_; }
 
   /**
    * \brief Sets user data on all ogre objects we own
@@ -134,16 +134,22 @@ public:
 private:
   Ogre::SceneNode* frame_node_;
   Ogre::SceneNode* position_node_;
-  Ogre::SceneNode* orientation_node_;
+  Ogre::SceneNode* orientation_x_node_;
+  Ogre::SceneNode* orientation_y_node_;
+  Ogre::SceneNode* orientation_z_node_;
 
   rviz::Shape* position_shape_;   ///< Ellipse used for the position covariance
-  rviz::Shape* orientation_shape_;   ///< Cone used for the orientation covariance
+  rviz::Shape* orientation_x_shape_;   ///< Cylinder used for the covariance of pitch-yaw
+  rviz::Shape* orientation_y_shape_;   ///< Cylinder used for the covariance of roll-yaw
+  rviz::Shape* orientation_z_shape_;   ///< Cylinder used for the covariance of roll-pitch
 
   float position_scale_factor_;
   float orientation_scale_factor_;
 
   boost::scoped_ptr<Ogre::Vector3> position_msg_scale_;
-  boost::scoped_ptr<Ogre::Vector3> orientation_msg_scale_;
+  boost::scoped_ptr<Ogre::Vector3> orientation_x_msg_scale_;
+  boost::scoped_ptr<Ogre::Vector3> orientation_y_msg_scale_;
+  boost::scoped_ptr<Ogre::Vector3> orientation_z_msg_scale_;
 
 // Hide Object methods we don't want to expose
 // NOTE: Apparently we still need to define them...

--- a/src/covariance_visual.h
+++ b/src/covariance_visual.h
@@ -41,7 +41,7 @@ public:
    * @param pos_scale Scale of the position covariance
    * @param ori_scale Scale of the orientation covariance
    */
-  CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, bool is_visible = true, float pos_scale = 1.0f, float ori_scale = 0.1f);
+  CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, bool is_visible = true, float pos_scale = 1.0f, float ori_scale = 0.1f, bool use_rotating_frame = true);
   virtual ~CovarianceVisual();
 
   /**
@@ -140,6 +140,10 @@ public:
    */
   virtual void setFrameOrientation( const Ogre::Quaternion& orientation );
 
+  /**
+   * \brief Sets which frame to attach the covariance of the orientation
+   */
+  virtual void setRotatingFrame( bool use_rotating_frame );
 
 private:
   Ogre::SceneNode* frame_node_;
@@ -160,6 +164,8 @@ private:
   boost::scoped_ptr<Ogre::Vector3> orientation_x_msg_scale_;
   boost::scoped_ptr<Ogre::Vector3> orientation_y_msg_scale_;
   boost::scoped_ptr<Ogre::Vector3> orientation_z_msg_scale_;
+
+  bool use_rotating_frame_;
 
 // Hide Object methods we don't want to expose
 // NOTE: Apparently we still need to define them...

--- a/src/covariance_visual.h
+++ b/src/covariance_visual.h
@@ -4,16 +4,15 @@
 #include <rviz/ogre_helpers/object.h>
 
 #include <boost/scoped_ptr.hpp>
-#include <boost/array.hpp>
 
 #include <geometry_msgs/PoseWithCovariance.h>
+
+#include <Eigen/Dense>
 
 namespace Ogre
 {
 class SceneManager;
 class SceneNode;
-class Vector3;
-class Quaternion;
 class ColourValue;
 class Any;
 }
@@ -23,25 +22,45 @@ namespace rviz
 class Shape;
 }
 
+namespace Eigen
+{
+  typedef Matrix<double,6,6> Matrix6d;
+}
+
 namespace rviz_plugin_covariance
 {
 
+class CovarianceProperty;
+
 /**
  * \class CovarianceVisual
- * \brief CovarianceVisual consisting in a sphere for position and cone (?) for orientation.
+ * \brief CovarianceVisual consisting in a ellipse for position and 2D ellipses along the axis for orientation.
  */
 class CovarianceVisual : public rviz::Object
 {
 public:
+  enum BryanAngle
+  {
+    kRoll=0,
+    kPitch=1,
+    kYaw=2
+  };
+
+private:
   /**
-   * \brief Constructor
+   * \brief Private Constructor
+   * 
+   * CovarianceVisual can only be constructed by friend class CovarianceProperty.
    *
    * @param scene_manager The scene manager to use to construct any necessary objects
    * @param parent_object A rviz object that this covariance will be attached.
+   * @param is_local_rotation Initial attachment of the rotation part
+   * @param is_visible Initial visibility
    * @param pos_scale Scale of the position covariance
    * @param ori_scale Scale of the orientation covariance
    */
-  CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, bool is_visible = true, float pos_scale = 1.0f, float ori_scale = 0.1f, bool use_rotating_frame = true);
+  CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::SceneNode* parent_node, bool is_local_rotation, bool is_visible = true, float pos_scale = 1.0f, float ori_scale = 0.1f);
+public:
   virtual ~CovarianceVisual();
 
   /**
@@ -79,7 +98,7 @@ public:
    * This effectively changes the orientation and scale of position and orientation 
    * covariance shapes
    */
-  virtual void setCovariance( const geometry_msgs::PoseWithCovariance& message );
+  virtual void setCovariance( const geometry_msgs::PoseWithCovariance& pose );
 
   virtual const Ogre::Vector3& getPositionCovarianceScale();
   virtual const Ogre::Quaternion& getPositionCovarianceOrientation();
@@ -88,37 +107,24 @@ public:
    * \brief Get the scene node the frame this covariance is defined
    * @return the scene node associated with frame this covariance is defined
    */
-  Ogre::SceneNode* getFrameSceneNode() { return frame_node_; }
+  Ogre::SceneNode* getSceneNode() { return root_node_; }
 
   /**
-   * \brief Get the scene node associated with the position covariance
-   * @return the scene node associated with the position covariance
+   * \brief Get the shape used to display position covariance
+   * @return the shape used to display position covariance
    */
-  Ogre::SceneNode* getPositionSceneNode() { return position_node_; }
-
-  /**
-   * \brief Get the scene node associated with the orientation covariance
-   * @return the scene node associated with the orientation covariance
-   */
-  // TODO: Add methods to get other orientation scene nodes as well
-  Ogre::SceneNode* getOrientationSceneNode() { return orientation_x_node_; }
-
   rviz::Shape* getPositionShape() { return position_shape_; }
-  // TODO: Add methods to get other orientation shapes as well
-  rviz::Shape* getOrientationShape() { return orientation_x_shape_; }
+
+  /**
+   * \brief Get the shape used to display orientation covariance in an especific axis
+   * @return the shape used to display orientation covariance in an especific axis
+   */  
+  rviz::Shape* getOrientationShape(BryanAngle angle);
 
   /**
    * \brief Sets user data on all ogre objects we own
    */
   virtual void setUserData( const Ogre::Any& data );
-
-  /**
-   * \brief Sets visibility of this covariance
-   *
-   * This convenience function sets the visibility of the both position and orientation
-   * scene nodes 
-   */
-  virtual void setVisible( bool visible );
 
   /**
    * \brief Sets visibility of the position part of this covariance
@@ -133,12 +139,12 @@ public:
   /**
    * \brief Sets position of the frame this covariance is attached
    */
-  virtual void setFramePosition( const Ogre::Vector3& position );
+  virtual void setPosition( const Ogre::Vector3& position );
 
   /**
    * \brief Sets orientation of the frame this covariance is attached
    */
-  virtual void setFrameOrientation( const Ogre::Quaternion& orientation );
+  virtual void setOrientation( const Ogre::Quaternion& orientation );
 
   /**
    * \brief Sets which frame to attach the covariance of the orientation
@@ -146,37 +152,33 @@ public:
   virtual void setRotatingFrame( bool use_rotating_frame );
 
 private:
-  Ogre::SceneNode* frame_node_;
+  void updatePosition( const Eigen::Matrix6d& covariance );
+  void updateOrientation( const Eigen::Matrix6d& covariance, BryanAngle angle );
+
+  Ogre::SceneNode* root_node_;
+  Ogre::SceneNode* fixed_orientation_node_;
+  Ogre::SceneNode* position_scale_node_;
   Ogre::SceneNode* position_node_;
-  Ogre::SceneNode* orientation_x_node_;
-  Ogre::SceneNode* orientation_y_node_;
-  Ogre::SceneNode* orientation_z_node_;
+
+  Ogre::SceneNode* orientation_scale_node_;
+  Ogre::SceneNode* orientation_offset_node_[3];
+  Ogre::SceneNode* orientation_node_[3];
 
   rviz::Shape* position_shape_;   ///< Ellipse used for the position covariance
-  rviz::Shape* orientation_x_shape_;   ///< Cylinder used for the covariance of pitch-yaw
-  rviz::Shape* orientation_y_shape_;   ///< Cylinder used for the covariance of roll-yaw
-  rviz::Shape* orientation_z_shape_;   ///< Cylinder used for the covariance of roll-pitch
+  rviz::Shape* orientation_shape_[3];   ///< Cylinders used for the orientation covariance
 
-  float position_scale_factor_;
-  float orientation_scale_factor_;
+  bool local_rotation_;
 
-  boost::scoped_ptr<Ogre::Vector3> position_msg_scale_;
-  boost::scoped_ptr<Ogre::Vector3> orientation_x_msg_scale_;
-  boost::scoped_ptr<Ogre::Vector3> orientation_y_msg_scale_;
-  boost::scoped_ptr<Ogre::Vector3> orientation_z_msg_scale_;
-
-  bool use_rotating_frame_;
-
-// Hide Object methods we don't want to expose
-// NOTE: Apparently we still need to define them...
 private:
-  virtual void setPosition( const Ogre::Vector3& position ) {};
-  virtual void setOrientation( const Ogre::Quaternion& orientation ) {};
+  // Hide Object methods we don't want to expose
+  // NOTE: Apparently we still need to define them...
   virtual void setScale( const Ogre::Vector3& scale ) {};
   virtual void setColor( float r, float g, float b, float a ) {};
   virtual const Ogre::Vector3& getPosition();
   virtual const Ogre::Quaternion& getOrientation();
 
+  // Make CovarianceProperty friend class so it create CovarianceVisual objects
+  friend class CovarianceProperty;
 };
 
 } // namespace rviz_plugin_covariance

--- a/src/covariance_visual.h
+++ b/src/covariance_visual.h
@@ -121,6 +121,16 @@ public:
   virtual void setVisible( bool visible );
 
   /**
+   * \brief Sets visibility of the position part of this covariance
+   */
+  virtual void setPositionVisible( bool visible );
+
+  /**
+   * \brief Sets visibility of the orientation part of this covariance
+   */
+  virtual void setOrientationVisible( bool visible );
+
+  /**
    * \brief Sets position of the frame this covariance is attached
    */
   virtual void setFramePosition( const Ogre::Vector3& position );

--- a/src/odometry_display.h
+++ b/src/odometry_display.h
@@ -27,7 +27,6 @@ class EnumProperty;
 namespace rviz_plugin_covariance
 {
 
-class CovarianceVisual;
 class CovarianceProperty;
 
 /**
@@ -73,12 +72,9 @@ private:
 
   typedef std::deque<rviz::Arrow*> D_Arrow;
   typedef std::deque<rviz::Axes*> D_Axes;
-  typedef boost::shared_ptr<CovarianceVisual> CovarianceVisualPtr;
-  typedef std::deque<CovarianceVisualPtr> D_Covariance;
 
   D_Arrow arrows_;
   D_Axes axes_;
-  D_Covariance covariances_;
 
   nav_msgs::Odometry::ConstPtr last_used_message_;
 

--- a/src/odometry_display.h
+++ b/src/odometry_display.h
@@ -63,9 +63,6 @@ private Q_SLOTS:
   void updateColorAndAlpha();
   void updateArrowsGeometry();
   void updateAxisGeometry();
-  void updateCovarianceChoice();
-  void updateCovarianceVisibility();
-  void updateCovarianceColorAndAlphaAndScale();
 
 private:
   void updateGeometry( rviz::Arrow* arrow );
@@ -76,7 +73,8 @@ private:
 
   typedef std::deque<rviz::Arrow*> D_Arrow;
   typedef std::deque<rviz::Axes*> D_Axes;
-  typedef std::deque<CovarianceVisual*> D_Covariance;
+  typedef boost::shared_ptr<CovarianceVisual> CovarianceVisualPtr;
+  typedef std::deque<CovarianceVisualPtr> D_Covariance;
 
   D_Arrow arrows_;
   D_Axes axes_;

--- a/src/pose_with_covariance_display.cpp
+++ b/src/pose_with_covariance_display.cpp
@@ -334,7 +334,17 @@ void PoseWithCovarianceDisplay::updateCovarianceVisibility()
   else
   {
     bool show_covariance = covariance_property_->getBool();
-    covariance_->setVisible( show_covariance );
+    if( !show_covariance )
+    {
+      covariance_->setVisible( false );
+    }
+    else
+    {
+      bool show_position_covariance = covariance_property_->getPositionBool();
+      covariance_->setPositionVisible( show_position_covariance );
+      bool show_orientation_covariance = covariance_property_->getOrientationBool();
+      covariance_->setOrientationVisible( show_orientation_covariance );
+    }
   }
 }
 

--- a/src/pose_with_covariance_display.cpp
+++ b/src/pose_with_covariance_display.cpp
@@ -265,6 +265,9 @@ void PoseWithCovarianceDisplay::updateCovarianceColorAndAlphaAndScale()
   covariance_->setOrientationColor( color );
   covariance_->setOrientationScale( covariance_property_->getOrientationScale() );
 
+  bool use_rotating_frame = ( covariance_property_->getOrientationFrameOptionInt() == CovarianceProperty::Rotating );
+  covariance_->setRotatingFrame( use_rotating_frame );
+
   context_->queueRender();
 }
 

--- a/src/pose_with_covariance_display.h
+++ b/src/pose_with_covariance_display.h
@@ -66,7 +66,6 @@ private:
   rviz::Axes* axes_;
   boost::shared_ptr<CovarianceVisual> covariance_;
   bool pose_valid_;
-  bool covariance_valid_;
   PoseWithCovarianceDisplaySelectionHandlerPtr coll_handler_;
 
   rviz::EnumProperty* shape_property_;

--- a/src/pose_with_covariance_display.h
+++ b/src/pose_with_covariance_display.h
@@ -52,13 +52,10 @@ protected:
 
 private Q_SLOTS:
   void updateShapeVisibility();
-  void updateCovarianceVisibility();
   void updateColorAndAlpha();
   void updateShapeChoice();
   void updateAxisGeometry();
   void updateArrowGeometry();
-  void updateCovarianceChoice();
-  void updateCovarianceColorAndAlphaAndScale();
 
 private:
   void clear();
@@ -67,7 +64,7 @@ private:
 
   rviz::Arrow* arrow_;
   rviz::Axes* axes_;
-  CovarianceVisual* covariance_;
+  boost::shared_ptr<CovarianceVisual> covariance_;
   bool pose_valid_;
   bool covariance_valid_;
   PoseWithCovarianceDisplaySelectionHandlerPtr coll_handler_;


### PR DESCRIPTION
This PR fixes #13 .

3D orientation covariances is represented as flat ellipses along the axes. I'm probably still going do to some cleaning in the code before merging to make it easier to understand, but the mechanism to show the covariances should be the same. 

I decided to add an option to control if the orientation covariance is expressed in the rotating frame or the static frame. I took the opportunity to reorganize the covariance property a bit as well.

I'll let this PR open for a few days for testing before merging it on indigo branch.