### PR TITLE
Fix for rviz crash when creating the display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,20 +5,38 @@ catkin_package()
 include_directories(${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
-find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
-include(${QT_USE_FILE})
+if (rviz_QT_VERSION VERSION_GREATER "5.0.0")
+  find_package(Qt5Core)
+  find_package(Qt5Gui)
+
+  include_directories(${Qt5Core_INCLUDE_DIRS} ${Qt5Gui_INCLUDE_DIRS})
+  
+  set(QT_LIBRARIES ${Qt5Core_LIBRARIES} ${Qt5Gui_LIBRARIES})
+
+  qt5_wrap_cpp(MOC_FILES
+    src/pose_with_covariance_display.h
+    src/odometry_display.h
+    src/covariance_visual.h
+    src/covariance_property.h
+  )
+
+else()
+  find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
+  include(${QT_USE_FILE})
+
+  qt4_wrap_cpp(MOC_FILES
+    src/pose_with_covariance_display.h
+    src/odometry_display.h
+    src/covariance_visual.h
+    src/covariance_property.h
+  )
+
+endif()
 
 find_package(Eigen REQUIRED)
 include_directories(${EIGEN_INCLUDE_DIR})
 
 add_definitions(-DQT_NO_KEYWORDS)
-
-qt4_wrap_cpp(MOC_FILES
-  src/pose_with_covariance_display.h
-  src/odometry_display.h
-  src/covariance_visual.h
-  src/covariance_property.h
-)
 
 set(SOURCE_FILES
   src/covariance_visual.cpp

--- a/src/covariance_visual.cpp
+++ b/src/covariance_visual.cpp
@@ -200,6 +200,9 @@ CovarianceVisual::CovarianceVisual( Ogre::SceneManager* scene_manager, Ogre::Sce
       orientation_shape_[i] = new rviz::Shape(rviz::Shape::Cylinder, scene_manager_, orientation_offset_node_[i]);
     else
       orientation_shape_[i] = new rviz::Shape(rviz::Shape::Cone, scene_manager_, orientation_offset_node_[i]);
+
+    // Initialize all current scales to 0
+    current_ori_scale_[i] = Ogre::Vector3(0,0,0);
   }
 
   // Position the cylindes at position 1.0 in the respective axis, and perpendicular to the axis.


### PR DESCRIPTION
RViz would randomly crash when creating the PoseWithCovariance marker with the following error message:

`rviz: /build/ogre-1.9-mqY1wq/ogre-1.9-1.9.0+dfsg1/OgreMain/src/OgreNode.cpp:630: virtual void Ogre::Node::setScale(const Ogre::Vector3&): Assertion `!inScale.isNaN() && "Invalid vector supplied as parameter"' failed.`

The crash was due to uninitialized values in the `current_ori_scale_` array which would sometimes be interpreted as `nan`. This pull request fixes the issue.